### PR TITLE
9.test

### DIFF
--- a/controllers/thoughtCountroller.js
+++ b/controllers/thoughtCountroller.js
@@ -77,8 +77,8 @@ module.exports = {
         });
       }
       const removeThoughtFromUser = await User.findOneAndUpdate(
-        { _id: req.params.thoughtId },
-        { $pull: { thoughts: req.params.thoughtId} },
+        { thoughts: req.params.thoughtId },
+        { $pull: { thoughts: req.params.thoughtId } },
         { new: true }
       );
       if (!removeThoughtFromUser) {
@@ -116,7 +116,7 @@ module.exports = {
     try {
       const removeFromThought = await Thought.findOneAndUpdate(
         { _id: req.params.thoughtId },
-        { $pull: { reactions: req.params.reactionId } },
+        { $pull: { reactions:{ reactionId: req.params.reactionId} } },
         { runValidators: true, new: true }
       );
       if (!removeFromThought) {

--- a/routes/api/thoughtRoutes.js
+++ b/routes/api/thoughtRoutes.js
@@ -15,7 +15,10 @@ router.route('/').get(getAllThoughts).post(createThought);
 // /api/thoughts/:thoughtId
 router.route('/:thoughtId').get(getOneThought).put(updateThought).delete(deleteThought);
 
+// /api/thoughts/:thoughtId/reactions/
+router.route('/:thoughtId/reactions').post(addReaction)
+
 // /api/thoughts/:thoughtId/reactions/:reactionId
-router.route('/:thoughtId/reactions/:reactionId').post(addReaction).delete(deleteReaction)
+router.route('/:thoughtId/reactions/:reactionId').delete(deleteReaction)
 
 module.exports = router;


### PR DESCRIPTION
`decoupled reaction routes`
- I think I copied userRoutes to thoughtRoutes and only changed the wording so I missed a step where you have to decouple post and delete requests for reactions. It looked weird during testing cause how would i be able to reference reactionId if the reaction hasn't even been created. dumb.

`corrected removeThoughtFromUser`
- i used `_id: req.params.thoughtId` instead of `thoughts: req.params.thoughtId` so it ended up not being able to target anything from the thoughts array. dumb dumb

added correct pull destination from removeFromThought
- originally it was `{ $pull: { reactions: req.params.reactionId} }` and it didn't work. I guess I didn't pinpoint exactly where it should be targeting? corrected to `{ $pull: { reactions:{ reactionId: req.params.reactionId} } }` and now it works. dumb dumb dumb
